### PR TITLE
Link to Environment.swift

### DIFF
--- a/TargetSharingKit/Package.swift
+++ b/TargetSharingKit/Package.swift
@@ -61,7 +61,6 @@ let package = Package(
         .target(
             name: "Testing",
             dependencies: [
-                "Environment",
             ],
             path: "Testing/Sources"
         ),

--- a/TargetSharingKit/Testing/Sources/Environment.swift
+++ b/TargetSharingKit/Testing/Sources/Environment.swift
@@ -1,0 +1,1 @@
+../../Environment/Sources/Environment.swift

--- a/TargetSharingKit/Testing/Sources/XCUIApplication+Environment.swift
+++ b/TargetSharingKit/Testing/Sources/XCUIApplication+Environment.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import Environment
 
 extension XCTestCase {
     public static var uiTestLaunchArgument: String {


### PR DESCRIPTION
Adding `Environment` as a dependency to both `Working` and `Testing` targets causes the following error when building the Xcode test targets `TargetSharingExampleTests` and `TargetSharingExampleUITests`:

> Swift package target 'Environment' is linked as a static library by 'TargetSharingExampleTests' and 'TargetSharingExample'. This will result in duplication of library code.

The only way I've been able to solve this is by creating a soft-link to `Environment.swift` inside `Testing/Sources`.
